### PR TITLE
Feat: Ability to build session trajectory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,11 @@
+.DS_Store
 .env
 .venv
 .vscode
 .ruff_cache
 .ipynb_checkpoints
 recordings/
+trajectories/
 __pycache__/
 *.pyc
 *.pyo

--- a/record.ipynb
+++ b/record.ipynb
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -142,11 +142,62 @@
    "source": [
     "await recording.replay() #replays on a local browser instance, can pass in a cdp url to replay on a remote browser"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "86"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "events_path = \"recordings/events.json\"\n",
+    "recording = Recording.from_file(events_path)\n",
+    "\n",
+    "trajectory = await recording.get_trajectory()\n",
+    "\n",
+    "len(trajectory.snapshots)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully exported recording\n"
+     ]
+    }
+   ],
+   "source": [
+    "from web_recorder.recorder import ExportFormat, ExportConfig\n",
+    "events_path = \"recordings/events.json\"\n",
+    "recording = Recording.from_file(events_path)\n",
+    "\n",
+    "await recording.export(\n",
+    "    path=\"./trajectories/trajectory.json\",\n",
+    "    config=ExportConfig(\n",
+    "        format=ExportFormat.TRAJECTORY,\n",
+    "    ),\n",
+    ")"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "foundryml",
+   "display_name": "foundryml-sMtWArYk-py3.12",
    "language": "python",
    "name": "python3"
   },

--- a/record.ipynb
+++ b/record.ipynb
@@ -55,6 +55,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Record a session**\n",
+    "\n",
+    "This will start recording your browser session. The recorder will capture all page loads, dom changes, and user interactions, including:\n",
+    "- Mouse clicks\n",
+    "- Mouse movements\n",
+    "- Scrolling\n",
+    "- Text input\n",
+    "- Page navigation\n",
+    "- Page loads\n",
+    "\n",
+    "To stop recording, simply close the browser tab that was opened."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
@@ -63,7 +80,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Task ID: 4ba7a19c-290f-4593-91d3-155b50c31b20\n"
+      "Task ID: d30ad367-0dd0-4dc8-8dbf-8622764b5ae6\n",
+      "Recording completed\n"
      ]
     }
    ],
@@ -77,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,14 +103,48 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "recording.export(\n",
+    "**Export recording**\n",
+    "\n",
+    "Export the recording to a file. \n",
+    "\n",
+    "The export path can be:\n",
+    "- Local file path (e.g. \"recordings/events.json\") \n",
+    "- S3 path (e.g. \"s3://bucket/path/to/file.json\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Successfully exported recording\n"
+     ]
+    }
+   ],
+   "source": [
+    "await recording.export(\n",
     "  path=events_path,\n",
     ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Load recording from file**\n",
+    "\n",
+    "Load a previously exported recording from a file.\n",
+    "\n",
+    "The file path can be:\n",
+    "- Local file path (e.g. \"recordings/events.json\")\n",
+    "- S3 path (e.g. \"s3://bucket/path/to/file.json\")\n"
    ]
   },
   {
@@ -108,16 +160,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "228"
+       "197"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -127,38 +179,90 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Replay recording**\n",
+    "\n",
+    "Replay the recording in a browser. By default it uses a local browser instance.\n",
+    "\n",
+    "You can pass in a CDP URL to replay on a remote browser instance.\n",
+    "\n",
+    "Example:\n",
+    "```python\n",
+    "# Remote replay\n",
+    "await recording.replay(cdp_url=\"ws://remote-browser:9222\")\n",
+    "```\n"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "number of events 2\n"
+      "Replay completed\n"
      ]
     }
    ],
    "source": [
-    "await recording.replay() #replays on a local browser instance, can pass in a cdp url to replay on a remote browser"
+    "await recording.replay()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Export session as trajectory**\n",
+    "\n",
+    "Export the recording as a trajectory format that captures puts out dom for each action from the session.\n",
+    "This is helpful for:\n",
+    "- Analyzing user interactions and page states over time\n",
+    "- Training ML models on web interactions\n",
+    "- Debugging issues by examining the DOM state at each action\n",
+    "- Creating structured data from web sessions\n",
+    "\n",
+    "Schema:\n",
+    "\n",
+    "```json\n",
+    "{\n",
+    "  \"id\": \"123\",\n",
+    "  \"snapshots\": [\n",
+    "    {\n",
+    "      \"action\": \"page_load\",\n",
+    "      \"timestamp\": 100,\n",
+    "      \"state\": \"<html>...</html>\",\n",
+    "      \"metadata\": {\n",
+    "        \"url\": \"https://example.com\"\n",
+    "      },\n",
+    "    },\n",
+    "    {\n",
+    "      \"action\": \"click\",\n",
+    "      \"timestamp\": 101,\n",
+    "      \"state\": \"<html>...</html>\",\n",
+    "      \"metadata\": { ... },\n",
+    "      \"element\": \"<button>...</button>\"\n",
+    "    },\n",
+    "    ...\n",
+    "  ]\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate and use trajectory"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "86"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "events_path = \"recordings/events.json\"\n",
     "recording = Recording.from_file(events_path)\n",
@@ -169,8 +273,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Generate and export to a path"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {

--- a/web_recorder/js/get_rrweb_dom_node.js
+++ b/web_recorder/js/get_rrweb_dom_node.js
@@ -1,0 +1,48 @@
+([nodeId, eventSource]) => {
+  const node = window.player.getMirror().getNode(nodeId);
+
+  // Events referenced from here: https://github.com/rrweb-io/rrweb/blob/fd9d2747c6a236975055a69165ccce640b029015/docs/recipes/dive-into-event.md
+  const CLICKABLE_EVENT_SOURCES = [2];
+  if (!node) return null;
+
+  if (CLICKABLE_EVENT_SOURCES.includes(eventSource)) {
+    // Traverse up to find clickable elements instead of the subnode that was clicked directly
+    let current = node;
+    const interactable_tags = [
+      "A",
+      "BUTTON",
+      "INPUT",
+      "TEXTAREA",
+      "SELECT",
+      "OPTION",
+      "LABEL",
+      "CHECKBOX",
+      "RADIO",
+    ];
+    while (
+      current &&
+      current.textContent.trim() === node.textContent.trim() &&
+      current.tagName !== "BODY"
+    ) {
+      if (
+        interactable_tags.includes(current.tagName) ||
+        current.getAttribute("role") === "button"
+      ) {
+        return current.outerHTML;
+      }
+      current = current.parentElement;
+    }
+
+    if (
+      !current ||
+      !interactable_tags.includes(current.tagName) ||
+      current.getAttribute("role") !== "button"
+    ) {
+      return node.outerHTML;
+    }
+
+    return current.outerHTML;
+  }
+
+  return node.outerHTML;
+};

--- a/web_recorder/recorder.py
+++ b/web_recorder/recorder.py
@@ -54,7 +54,7 @@ class ExportFormat(Enum):
 
 
 class ExportConfig(BaseModel):
-    format: ExportFormat
+    format: ExportFormat = ExportFormat.RRWEB
 
 
 class Trajectory(BaseModel):
@@ -76,7 +76,7 @@ class Recording(BaseModel):
             Body=self.__export_json(),
         )
 
-    async def export(self, path: str, config: ExportConfig):
+    async def export(self, path: str, config: ExportConfig = ExportConfig()):
         if config.format == ExportFormat.RRWEB:
             data = self.__export_json()
         elif config.format == ExportFormat.TRAJECTORY:
@@ -149,7 +149,7 @@ class Recording(BaseModel):
 
 
 class Recorder:
-    def __init__(self, cdp_url: str):
+    def __init__(self, cdp_url: Optional[str] = None):
         self.cdp_url = cdp_url
 
     async def record(self):

--- a/web_recorder/replayer.py
+++ b/web_recorder/replayer.py
@@ -1,46 +1,16 @@
 import asyncio
+import time
+
 from playwright.async_api import Page, Browser
 
-
-async def inject_rrweb_player(page: Page):
-    if page.is_closed():
-        return
-
-    # check if rrweb-player is already injected
-    is_player_available = await page.evaluate("typeof rrwebPlayer !== 'undefined'")
-    if is_player_available:
-        return
-
-    await page.add_style_tag(
-        url="https://cdn.jsdelivr.net/npm/rrweb-player@2.0.0-alpha.18/dist/style.css"
-    )
-    await page.add_script_tag(path="web_recorder/rrweb/rrweb-player.js")
-
-    try:
-        await page.wait_for_load_state("networkidle")
-    except Exception as e:
-        print(f"Warning: Unable to wait for network idle: {e}")
-
-    # Verify rrweb-player is available
-    max_retries = 3
-    retries = 0
-    while retries < max_retries:
-        is_player_available = await page.evaluate("typeof rrwebPlayer !== 'undefined'")
-        if is_player_available:
-            break
-        retries += 1
-        await asyncio.sleep(1)
-    if not is_player_available:
-        raise Exception("rrweb-player failed to load properly")
+from web_recorder.utils import generate_dom_events, create_trajectory_snapshot
 
 
 async def setup_player(page: Page, events: list):
     # check if player is already setup
     is_player_available = await page.evaluate("typeof player !== 'undefined'")
     if is_player_available:
-        return
-
-    print("number of events", len(events))
+        return False
 
     # player requires at least 2 events to start
     # Can't send all events because if we have a lot of events during init, the player freezes.
@@ -66,6 +36,8 @@ async def setup_player(page: Page, events: list):
     """,
         [events[:required_events]],
     )
+
+    return True
 
 
 async def replay_events(browser: Browser, events: list):
@@ -146,3 +118,67 @@ def fix_event_timestamps(events: list):
         if events[i]["timestamp"] == events[i - 1]["timestamp"]:
             events[i]["timestamp"] = events[i - 1]["timestamp"] + 1
     return events
+
+
+async def wait_for_player(page: Page, timeout: int = 30):
+    """
+    Wait for the rrweb player to be available.
+    This is a helper function to wait for the player to be available before
+    setting up the player.
+
+    Args:
+        page: The page to wait for the player on.
+        timeout: The timeout for the player to be available in seconds.
+
+    Raises:
+        Exception: If the player is not available after the timeout.
+
+    Returns:
+        None
+    """
+    start_time = time.time()
+    while True:
+        rrweb_player_available = await page.evaluate(
+            "typeof rrwebPlayer !== 'undefined'"
+        )
+        if rrweb_player_available:
+            break
+
+        await asyncio.sleep(1)
+
+        if time.time() - start_time > timeout:
+            raise Exception("Player not available after timeout")
+
+
+async def build_trajectory_snapshots(browser: Browser, events: list):
+    """Build the DOM for the events and generate trajectory snapshots"""
+
+    # Create context and page
+    context = await browser.new_context(
+        bypass_csp=True,
+    )
+    await context.add_init_script(path="web_recorder/rrweb/rrweb.js")
+    await context.add_init_script(path="web_recorder/rrweb/rrweb-player.js")
+
+    page = await context.new_page()
+
+    try:
+        await wait_for_player(page)
+
+        if not await setup_player(page, events):
+            raise Exception("Player not available")
+
+        # Fix timestamps
+        events = fix_event_timestamps(events)
+        dom_events = await generate_dom_events(page, events)
+
+        trajectory_snapshots = [
+            create_trajectory_snapshot(event) for event in dom_events
+        ]
+        return [snapshot for snapshot in trajectory_snapshots if snapshot is not None]
+
+    except Exception as e:
+        print(f"Error building DOM: {e}")
+        raise e
+    finally:
+        await context.close()

--- a/web_recorder/replayer.py
+++ b/web_recorder/replayer.py
@@ -1,9 +1,12 @@
 import asyncio
 import time
 
-from playwright.async_api import Page, Browser
+from playwright.async_api import Page, Browser, BrowserContext
 
-from web_recorder.utils import generate_dom_events, create_trajectory_snapshot
+from web_recorder.utils import (
+    generate_dom_events,
+    create_trajectory_snapshot,
+)
 
 
 async def setup_player(page: Page, events: list):
@@ -11,10 +14,6 @@ async def setup_player(page: Page, events: list):
     is_player_available = await page.evaluate("typeof player !== 'undefined'")
     if is_player_available:
         return False
-
-    # player requires at least 2 events to start
-    # Can't send all events because if we have a lot of events during init, the player freezes.
-    required_events = 2
 
     await page.evaluate(
         """
@@ -28,68 +27,51 @@ async def setup_player(page: Page, events: list):
                     autoPlay: false,
                     showWarning: true,
                     mouseTail: false,
-                    useVirtualDom: true
+                    useVirtualDom: true,
                 }
             });
             window.player = player;
         }
     """,
-        [events[:required_events]],
+        [events],
     )
 
     return True
 
 
+async def inject_rrweb_player_js(context: BrowserContext):
+    await context.add_init_script(path="web_recorder/rrweb/rrweb.js")
+    await context.add_init_script(path="web_recorder/rrweb/rrweb-player.js")
+
+
+async def inject_rrweb_player_css(page: Page):
+    await page.add_style_tag(
+        path="web_recorder/rrweb/rrweb-stylesheet.css"
+    )
+
+
 async def replay_events(browser: Browser, events: list):
     # fix event timestamps
-    events = fix_event_timestamps(events)
-
     try:
         context = await browser.new_context(
             bypass_csp=True,
         )
+
+        await inject_rrweb_player_js(context)
+
         page = await context.new_page()
-
-        # Setup rrweb injection on navigation
-        async def handle_navigation():
-            try:
-                player_available = await page.evaluate("typeof player !== 'undefined'")
-                if player_available:
-                    return
-
-                # Inject rrweb player
-                await inject_rrweb_player(page)
-                # Setup player
-                await setup_player(page, events)
-
-                print("rrweb player setup after navigation")
-            except Exception as e:
-                print(f"Error setting up rrweb player after navigation: {e}")
-
-        def handle_navigation_wrapper():
-            tasks = [
-                t for t in asyncio.all_tasks() if t.get_name() == "inject_rrweb_player"
-            ]
-            if not tasks:
-                task = asyncio.create_task(
-                    handle_navigation(), name="inject_rrweb_player"
-                )
-                task.add_done_callback(
-                    lambda t: t.exception()
-                    and print(f"Error in rrweb injection: {t.exception()}")
-                )
-
-        # Listen for frame navigation events
-        page.on("framenavigated", handle_navigation_wrapper)
-        page.on("load", handle_navigation_wrapper)
-        page.on("domcontentloaded", handle_navigation_wrapper)
+        await inject_rrweb_player_css(page)
 
         # Initial setup
-        await inject_rrweb_player(page)
-        await setup_player(page, events[:2])
+        await wait_for_player(page)
+
+        # player requires at least 2 events to start
+        # Can't send all events because if we have a lot of events during init, the player freezes.
+        rrweb_required_events = 2
+        await setup_player(page, events[:rrweb_required_events])
 
         # Add remaining events
-        for event in events[2:]:
+        for event in events[rrweb_required_events:]:
             await page.evaluate("([event]) => window.player.addEvent(event)", [event])
 
         await page.evaluate("() => window.player.play()")
@@ -110,15 +92,6 @@ async def replay_events(browser: Browser, events: list):
             await browser.close()
     except Exception as e:
         print(f"Error replaying events: {e}")
-
-
-def fix_event_timestamps(events: list):
-    """Fix event timestamps to not have duplicates"""
-    for i in range(1, len(events)):
-        if events[i]["timestamp"] == events[i - 1]["timestamp"]:
-            events[i]["timestamp"] = events[i - 1]["timestamp"] + 1
-    return events
-
 
 async def wait_for_player(page: Page, timeout: int = 30):
     """
@@ -157,8 +130,8 @@ async def build_trajectory_snapshots(browser: Browser, events: list):
     context = await browser.new_context(
         bypass_csp=True,
     )
-    await context.add_init_script(path="web_recorder/rrweb/rrweb.js")
-    await context.add_init_script(path="web_recorder/rrweb/rrweb-player.js")
+
+    await inject_rrweb_player_js(context)
 
     page = await context.new_page()
 
@@ -168,8 +141,6 @@ async def build_trajectory_snapshots(browser: Browser, events: list):
         if not await setup_player(page, events):
             raise Exception("Player not available")
 
-        # Fix timestamps
-        events = fix_event_timestamps(events)
         dom_events = await generate_dom_events(page, events)
 
         trajectory_snapshots = [

--- a/web_recorder/rrweb/rrweb-stylesheet.css
+++ b/web_recorder/rrweb/rrweb-stylesheet.css
@@ -1,0 +1,81 @@
+.switch.svelte-a6h7w7.svelte-a6h7w7.svelte-a6h7w7{height:1em;display:flex;align-items:center}.switch.disabled.svelte-a6h7w7.svelte-a6h7w7.svelte-a6h7w7{opacity:0.5}.label.svelte-a6h7w7.svelte-a6h7w7.svelte-a6h7w7{margin:0 8px}.switch.svelte-a6h7w7 input[type='checkbox'].svelte-a6h7w7.svelte-a6h7w7{position:absolute;opacity:0}.switch.svelte-a6h7w7 label.svelte-a6h7w7.svelte-a6h7w7{width:2em;height:1em;position:relative;cursor:pointer;display:block}.switch.disabled.svelte-a6h7w7 label.svelte-a6h7w7.svelte-a6h7w7{cursor:not-allowed}.switch.svelte-a6h7w7 label.svelte-a6h7w7.svelte-a6h7w7:before{content:'';position:absolute;width:2em;height:1em;left:0.1em;transition:background 0.1s ease;background:rgba(73, 80, 246, 0.5);border-radius:50px}.switch.svelte-a6h7w7 label.svelte-a6h7w7.svelte-a6h7w7:after{content:'';position:absolute;width:1em;height:1em;border-radius:50px;left:0;transition:all 0.2s ease;box-shadow:0px 2px 5px 0px rgba(0, 0, 0, 0.3);background:#fcfff4;animation:switch-off 0.2s ease-out;z-index:2}.switch.svelte-a6h7w7 input[type='checkbox'].svelte-a6h7w7:checked+label.svelte-a6h7w7:before{background:rgb(73, 80, 246)}.switch.svelte-a6h7w7 input[type='checkbox'].svelte-a6h7w7:checked+label.svelte-a6h7w7:after{animation:switch-on 0.2s ease-out;left:1.1em}.rr-controller.svelte-189zk2r.svelte-189zk2r{width:100%;height:80px;background:#fff;display:flex;flex-direction:column;justify-content:space-around;align-items:center;border-radius:0 0 5px 5px}.rr-timeline.svelte-189zk2r.svelte-189zk2r{width:80%;display:flex;align-items:center}.rr-timeline__time.svelte-189zk2r.svelte-189zk2r{display:inline-block;width:100px;text-align:center;color:#11103e}.rr-progress.svelte-189zk2r.svelte-189zk2r{flex:1;height:12px;background:#eee;position:relative;border-radius:3px;cursor:pointer;box-sizing:border-box;border-top:solid 4px #fff;border-bottom:solid 4px #fff}.rr-progress.disabled.svelte-189zk2r.svelte-189zk2r{cursor:not-allowed}.rr-progress__step.svelte-189zk2r.svelte-189zk2r{height:100%;position:absolute;left:0;top:0;background:#e0e1fe}.rr-progress__handler.svelte-189zk2r.svelte-189zk2r{width:20px;height:20px;border-radius:10px;position:absolute;top:2px;transform:translate(-50%, -50%);background:rgb(73, 80, 246)}.rr-controller__btns.svelte-189zk2r.svelte-189zk2r{display:flex;align-items:center;justify-content:center;font-size:13px}.rr-controller__btns.svelte-189zk2r button.svelte-189zk2r{width:32px;height:32px;display:flex;padding:0;align-items:center;justify-content:center;background:none;border:none;border-radius:50%;cursor:pointer}.rr-controller__btns.svelte-189zk2r button.svelte-189zk2r:active{background:#e0e1fe}.rr-controller__btns.svelte-189zk2r button.active.svelte-189zk2r{color:#fff;background:rgb(73, 80, 246)}.rr-controller__btns.svelte-189zk2r button.svelte-189zk2r:disabled{cursor:not-allowed}.replayer-wrapper {
+  position: relative;
+}
+.replayer-mouse {
+  position: absolute;
+  width: 20px;
+  height: 20px;
+  transition: left 0.05s linear, top 0.05s linear;
+  background-size: contain;
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-image: url('data:image/svg+xml;base64,PHN2ZyBoZWlnaHQ9JzMwMHB4JyB3aWR0aD0nMzAwcHgnICBmaWxsPSIjMDAwMDAwIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIGRhdGEtbmFtZT0iTGF5ZXIgMSIgdmlld0JveD0iMCAwIDUwIDUwIiB4PSIwcHgiIHk9IjBweCI+PHRpdGxlPkRlc2lnbl90bnA8L3RpdGxlPjxwYXRoIGQ9Ik00OC43MSw0Mi45MUwzNC4wOCwyOC4yOSw0NC4zMywxOEExLDEsMCwwLDAsNDQsMTYuMzlMMi4zNSwxLjA2QTEsMSwwLDAsMCwxLjA2LDIuMzVMMTYuMzksNDRhMSwxLDAsMCwwLDEuNjUuMzZMMjguMjksMzQuMDgsNDIuOTEsNDguNzFhMSwxLDAsMCwwLDEuNDEsMGw0LjM4LTQuMzhBMSwxLDAsMCwwLDQ4LjcxLDQyLjkxWm0tNS4wOSwzLjY3TDI5LDMyYTEsMSwwLDAsMC0xLjQxLDBsLTkuODUsOS44NUwzLjY5LDMuNjlsMzguMTIsMTRMMzIsMjcuNThBMSwxLDAsMCwwLDMyLDI5TDQ2LjU5LDQzLjYyWiI+PC9wYXRoPjwvc3ZnPg==');
+  border-color: transparent;  /* otherwise we transition from black when .touch-device class is added */
+}
+.replayer-mouse::after {
+  content: '';
+  display: inline-block;
+  width: 20px;
+  height: 20px;
+  background: rgb(73, 80, 246);
+  border-radius: 100%;
+  transform: translate(-50%, -50%);
+  opacity: 0.3;
+}
+.replayer-mouse.active::after {
+  animation: click 0.2s ease-in-out 1;
+}
+.replayer-mouse.touch-device {
+  background-image: none;  /* there's no passive cursor on touch-only screens */
+  width: 70px;
+  height: 70px;
+  border-width: 4px;
+  border-style: solid;
+  border-radius: 100%;
+  margin-left: -37px;
+  margin-top: -37px;
+  border-color: rgba(73, 80, 246, 0);
+  transition: left 0s linear, top 0s linear, border-color 0.2s ease-in-out;
+}
+.replayer-mouse.touch-device.touch-active {
+  border-color: rgba(73, 80, 246, 1);
+  transition: left 0.25s linear, top 0.25s linear, border-color 0.2s ease-in-out;
+}
+.replayer-mouse.touch-device::after {
+  opacity: 0;  /* there's no passive cursor on touch-only screens */
+}
+.replayer-mouse.touch-device.active::after {
+  animation: touch-click 0.2s ease-in-out 1;
+}
+.replayer-mouse-tail {
+  position: absolute;
+  pointer-events: none;
+}
+@keyframes click {
+  0% {
+    opacity: 0.3;
+    width: 20px;
+    height: 20px;
+  }
+  50% {
+    opacity: 0.5;
+    width: 10px;
+    height: 10px;
+  }
+}
+@keyframes touch-click {
+  0% {
+    opacity: 0;
+    width: 20px;
+    height: 20px;
+  }
+  50% {
+    opacity: 0.5;
+    width: 10px;
+    height: 10px;
+  }
+}
+.rr-player{position:relative;background:white;float:left;border-radius:5px;box-shadow:0 24px 48px rgba(17, 16, 62, 0.12)}
+.rr-player__frame{overflow:hidden}
+.replayer-wrapper{float:left;clear:both;transform-origin:top left;left:50%;top:50%}
+.replayer-wrapper>iframe{border:none}

--- a/web_recorder/rrweb/setup_recording.js
+++ b/web_recorder/rrweb/setup_recording.js
@@ -47,6 +47,14 @@ window.stopFn = rrweb.record({
   },
 });
 
+// Add custom event for page load completion
+window.addEventListener("load", () => {
+  rrweb.record.addCustomEvent("page-load", {
+    url: window.location.href,
+    timestamp: Date.now(),
+  });
+});
+
 // Function to send events via beacon
 window.sendEventsBG = () => {
   console.log("send events bg called");

--- a/web_recorder/rrweb/setup_recording.js
+++ b/web_recorder/rrweb/setup_recording.js
@@ -52,6 +52,7 @@ window.addEventListener("load", () => {
   rrweb.record.addCustomEvent("page-load", {
     url: window.location.href,
     timestamp: Date.now(),
+    state: document.documentElement.outerHTML,
   });
 });
 
@@ -82,49 +83,11 @@ window.sendEvents = async () => {
     const eventsToSend = [...window.events];
     window.events = [];
 
-    // console.log("Sending session events", eventsToSend);
-
     try {
-      // const response = await fetch("http://localhost:8002/api/events", {
-      //   method: "POST",
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //   },
-      //   body: JSON.stringify({
-      //     task_id: window.taskId,
-      //     events: eventsToSend,
-      //   }),
-      // });
-
       await window.store_events({
         task_id: window.taskId,
         events: eventsToSend,
       });
-
-      // const sessionEvent = new CustomEvent("session")
-
-      // sessionEvent.data = {
-      //   task_id: window.taskId,
-      //   events: eventsToSend,
-      // }
-
-      // console.debug("<session_event>", JSON.stringify({
-      //   task_id: window.taskId,
-      //   events: eventsToSend,
-      // }));
-
-      // window.dispatchEvent(sessionEvent);
-
-      // elem.dispatchEvent(event);
-
-      // window.postMessage({
-      //   task_id: window.taskId,
-      //   events: eventsToSend,
-      // });
-
-      // if (!response.ok) {
-      //   throw new Error(`HTTP error! status: ${response.status}`);
-      // }
     } catch (error) {
       console.error("Lost events:", error);
     }


### PR DESCRIPTION
**PR Changelog**

[Features]
- Add ability to build and export session trajectories.
- Add JavaScript script to build dom node from rrweb event.

[Refactors]
- Integrate custom page load event in utils to record page load for client side pages. 
- Define and emit page-load event in setup recording script.

[Fixes]
- Fix broken replayer styles.
- Make CDP URL an optional parameter
- Resolve local browser crash on exit during replay

[Chores]
- Update .gitignore file

[Docs]
- Add trajectory export examples to notebook
- Add helpful comments to notebook