### PR TITLE
Refactor: Move to jsonl for storage

### DIFF
--- a/record.ipynb
+++ b/record.ipynb
@@ -99,7 +99,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events_path = \"recordings/events.json\""
+    "events_path = \"recordings/events.jsonl\""
    ]
   },
   {
@@ -111,8 +111,8 @@
     "Export the recording to a file. \n",
     "\n",
     "The export path can be:\n",
-    "- Local file path (e.g. \"recordings/events.json\") \n",
-    "- S3 path (e.g. \"s3://bucket/path/to/file.json\")"
+    "- Local file path (e.g. \"recordings/events.jsonl\") \n",
+    "- S3 path (e.g. \"s3://bucket/path/to/file.jsonl\")"
    ]
   },
   {
@@ -143,8 +143,8 @@
     "Load a previously exported recording from a file.\n",
     "\n",
     "The file path can be:\n",
-    "- Local file path (e.g. \"recordings/events.json\")\n",
-    "- S3 path (e.g. \"s3://bucket/path/to/file.json\")\n"
+    "- Local file path (e.g. \"recordings/events.jsonl\")\n",
+    "- S3 path (e.g. \"s3://bucket/path/to/file.jsonl\")\n"
    ]
   },
   {
@@ -264,7 +264,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "events_path = \"recordings/events.json\"\n",
+    "events_path = \"recordings/events.jsonl\"\n",
     "recording = Recording.from_file(events_path)\n",
     "\n",
     "trajectory = await recording.get_trajectory()\n",
@@ -294,11 +294,11 @@
    ],
    "source": [
     "from web_recorder.recorder import ExportFormat, ExportConfig\n",
-    "events_path = \"recordings/events.json\"\n",
+    "events_path = \"recordings/events.jsonl\"\n",
     "recording = Recording.from_file(events_path)\n",
     "\n",
     "await recording.export(\n",
-    "    path=\"./trajectories/trajectory.json\",\n",
+    "    path=\"./trajectories/trajectory.jsonl\",\n",
     "    config=ExportConfig(\n",
     "        format=ExportFormat.TRAJECTORY,\n",
     "    ),\n",


### PR DESCRIPTION
[Refactors]
- Export rrweb events in JSONL.
- Export trajectory in JSONL.
- Update s3 export to use exact path instead of generating a name.

[Docs]
- Update notebook to use `.jsonl` file extension. 

Note: Changes file format, first line is metadata, whereas rest of the lines follow events or trajectory actions.